### PR TITLE
initial (Debian/Ubuntu only) support for openbox GUI

### DIFF
--- a/assets/home/bin/linuxdeploy
+++ b/assets/home/bin/linuxdeploy
@@ -331,6 +331,9 @@ configure_system()
 				kde)
 					echo 'startkde &' >> $MNT_TARGET$USER_HOME/.vnc/xstartup
 				;;
+				openbox)
+					echo 'exec openbox-session' >> $MNT_TARGET$USER_HOME/.vnc/xstartup
+				;;
 				esac
 				chmod 755 $MNT_TARGET$USER_HOME/.vnc/xstartup
 				echo "#!/bin/sh" > $MNT_TARGET$USER_HOME/.xsession
@@ -366,6 +369,9 @@ configure_system()
 				;;
 				kde)
 					PKGS="$PKGS kde-standard"
+				;;
+				openbox)
+					PKGS="$PKGS openbox"
 				;;
 				esac
 				chroot $MNT_TARGET apt-get install $PKGS --no-install-recommends -yq


### PR DESCRIPTION
tested on an existing Wheezy (with xterm GUI) deployment on my Note 10.1 running CM 10.1

this incorporates the extra package I had to install (apt-get install openbox) and the change I had to make to ~/.vnc/xstartup (exec openbox-session)

needs to be tested and expanded to other distros
