### PR TITLE
Fix initctl replacement so it doesn't break dpkg or get replaced on upgrade

### DIFF
--- a/assets/home/bin/linuxdeploy
+++ b/assets/home/bin/linuxdeploy
@@ -355,7 +355,7 @@ configure_system()
 		;;
 		upstart)
 			if [ -e "$MNT_TARGET/sbin/initctl" ]; then
-				rm $MNT_TARGET/sbin/initctl
+				chroot $MNT_TARGET dpkg-divert --local --rename --add /sbin/initctl
 				chroot $MNT_TARGET ln -s /bin/true /sbin/initctl
 			fi
 		;;


### PR DESCRIPTION
http://upstart.ubuntu.com/cookbook/#chroot-workaround-for-older-versions-of-upstart-debian-and-ubuntu-specific
