### PR TITLE
Alt key broken in VNC server 

### DIFF
--- a/assets/home/bin/linuxdeploy
+++ b/assets/home/bin/linuxdeploy
@@ -880,10 +880,12 @@ start_system()
 		if [ -z "$XSESSION" ]; then
 			(set -e
 				dbus_init
+				VNC_OPTIONS=""
 				# TightVNC Server
+				which Xtightvnc && VNC_OPTIONS="-compatiblekbd"
 				[ -e "$MNT_TARGET/tmp/.X$VNC_DISPLAY-lock" ] && rm $MNT_TARGET/tmp/.X$VNC_DISPLAY-lock
 				[ -e "$MNT_TARGET/tmp/.X11-unix/X$VNC_DISPLAY" ] && rm $MNT_TARGET/tmp/.X11-unix/X$VNC_DISPLAY
-				chroot $MNT_TARGET su - $USER_NAME -c "vncserver :$VNC_DISPLAY -depth $VNC_DEPTH -geometry $VNC_GEOMETRY -dpi $VNC_DPI"
+				chroot $MNT_TARGET su - $USER_NAME -c "vncserver :$VNC_DISPLAY -depth $VNC_DEPTH -geometry $VNC_GEOMETRY -dpi $VNC_DPI $VNC_OPTIONS"
 			exit 0)
 			[ $? -eq 0 ] && msg "done" || msg "fail"
 		else


### PR DESCRIPTION
Hello,

When using Debian testing with your wonderful LinuxDeploy tool for Android, I noticed that the Alt key is broken in the VNC server.  [The solution](http://www.realvnc.com/pipermail/vnc-list/2002-January/027719.html) is to pass the `-compatiblekbd` option to the `Xtightvnc` command in the `/data/local/bin/linuxdeploy` script.

Thanks for your consideration.
