### PR TITLE
user's $VNC_OPTIONS overridden if VNC is Xtightvnc

### DIFF
--- a/assets/home/bin/linuxdeploy
+++ b/assets/home/bin/linuxdeploy
@@ -882,7 +882,7 @@ start_system()
 				dbus_init
 				VNC_OPTIONS=""
 				# TightVNC Server
-				which Xtightvnc && VNC_OPTIONS="-compatiblekbd"
+				which Xtightvnc && VNC_OPTIONS="$VNC_OPTIONS -compatiblekbd"
 				[ -e "$MNT_TARGET/tmp/.X$VNC_DISPLAY-lock" ] && rm $MNT_TARGET/tmp/.X$VNC_DISPLAY-lock
 				[ -e "$MNT_TARGET/tmp/.X11-unix/X$VNC_DISPLAY" ] && rm $MNT_TARGET/tmp/.X11-unix/X$VNC_DISPLAY
 				chroot $MNT_TARGET su - $USER_NAME -c "vncserver :$VNC_DISPLAY -depth $VNC_DEPTH -geometry $VNC_GEOMETRY -dpi $VNC_DPI $VNC_OPTIONS"


### PR DESCRIPTION
Sorry, I didn't expect that both of my pull requests (they were mutually exclusive) would be merged! :sweat_smile: 

This patch fixes a bug where user-specified VNC_OPTIONS would be _overridden_ :bomb: if their chroot'ed Linux happens to be using Xtightvnc as the VNC server. :cake:
