### PR TITLE
fix permissions errors for tmp-mksh as well as check for bugged chroot

### DIFF
--- a/assets/home/bin/linuxdeploy
+++ b/assets/home/bin/linuxdeploy
@@ -24,6 +24,29 @@ exec 3>&1
 cd $ENV_DIR
 umask 0022
 
+# This shell seems to be screwing things up with the
+# built-in busybox shell. Lots of permissions errors.
+if [ "$SHELL" = "/tmp-mksh/tmp-mksh" ]; then
+  BIN_DIR="${ENV_DIR%/}/bin"
+  if [ "$(readlink "${BIN_DIR}/sh")" = "${BIN_DIR}/busybox" ]; then
+    rm "${BIN_DIR}/sh" || { echo "fail"; exit 1; }
+    ln -s /system/bin/mksh "${BIN_DIR}/sh" || { echo "fail"; exit 1; }
+  fi
+  if [ "$(readlink "${BIN_DIR}/chroot")" = "${BIN_DIR}/busybox" ]; then
+    if [ ! -e /system/xbin/busybox ]; then
+      echo "Please install the latest busybox-armv7l to /system/xbin"
+      exit 1
+    fi
+    # Older busybox versions and some busybox
+    # installers seem to get chattr and chroot mixed up.
+    if /system/xbin/busybox chroot @@@@@ 2>& 1 | grep -q -i "must use '-v'"; then
+      echo "Please install the latest busybox-armv7l to /system/xbin"
+      exit 1
+    fi
+    rm "${BIN_DIR}/chroot" || { echo "fail"; exit 1; }
+    ln -s /system/xbin/busybox "${BIN_DIR}/chroot" || { echo "fail"; exit 1; }
+  fi
+fi
 
 #################################################
 


### PR DESCRIPTION
This was the only way I could get linxudeploy working on android 4.4.2 (kernel 3.4.0):

This is mentioned here: http://forum.xda-developers.com/galaxy-s3/themes-apps/app-linux-deploy-t1929013/page3 and #60.

@meefik, I think you said this was fixed in 1.4.6, but I still run into the same issue mentioned in #60.

The relevant fix mentioned above:

``` bash
su -
cd /data/data/ru.meefik.linuxdeploy/linux/bin
rm sh chroot
ln -s /system/bin/mksh sh
ln -s /system/xbin/busybox chroot
```

However, after doing this, linxudeploy still didn't work for me due to a bugged /system busybox binary wherein busybox thought chroot was chattr. The new code also accounts for this and tells the user to upgrade to the latest busybox, or use the Busybox X installer (which worked for me).

I've modified the linuxdeploy script to account for this also.

This is untested, but I believe it should work. I'm relatively new to android, so I'm open to having any gotchas pointed out to me.

@meefik, I hope this gets fixed. Thank you for a great app.
