### PR TITLE
Make Fedora 21 the default Fedora

### DIFF
--- a/res/values/preferences.xml
+++ b/res/values/preferences.xml
@@ -74,7 +74,7 @@
     <string name="archlinux_architecture" translatable="false">armv7h</string>
 
     <!-- Fedora -->
-    <string name="fedora_suite" translatable="false">20</string>
+    <string name="fedora_suite" translatable="false">21</string>
     <string name="fedora_mirror" translatable="false">http://dl.fedoraproject.org/pub/</string>
     <string name="fedora_architecture" translatable="false">armhfp</string>
 


### PR DESCRIPTION
I've tested Fedora 21 and it works so he's a pull request to make it the default Fedora.
