### PR TITLE
Expand CHROOT command

### DIFF
--- a/assets/root/bin/linuxdeploy
+++ b/assets/root/bin/linuxdeploy
@@ -1148,7 +1148,13 @@ chroot_system()
 	fi
 	[ -z "$SHELL" ] && { msg "Shell not found!"; return 1; }
 
-	chroot $MNT_TARGET $SHELL 1>&3 2>&3
+	HOME=$2
+	if [ -z "$HOME" ]; then
+		chroot $MNT_TARGET /usr/bin/env -i HOME=$HOME TERM=linux $SHELL -l 1>&3 2>&3
+
+	else
+		chroot $MNT_TARGET $SHELL 1>&3 2>&3	
+	fi
 	[ $? -ne 0 ] && return 1
 
 	return 0
@@ -1694,7 +1700,7 @@ uninstall)
 ;;
 shell)
 	msg ">>> begin: $1"
-	chroot_system "$2"
+	chroot_system "$2" "$3"
 	msg "<<< end: $1"
 ;;
 status)


### PR DESCRIPTION
Expand CHROOT command to allow environment change including HOME directory, which is useful for SHELL login on some devices where HOME directory is not set by default for root user. For example, root user login to bash SHELL with /root as HOME directory:
linuxdeploy shell /bin/bash /root