### PR TITLE
initial Ubuntu amd64 support

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="ru.meefik.linuxdeploy"
-    android:versionCode="144"
+    android:versionCode="145"
     android:versionName="1.5.1" >
 
     <uses-sdk

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ Added fix for tty0 (use X options: "-sharevts vt0")
 Added handling for shutdown event
 Added support Ubuntu 15.10 (Wily Werewolf)
 Added support Fedora 22 (armhfp only)
+Added support Ubuntu amd64
 Added more locales
 Translated into German, Italian, Spanish and Chinese
 
@@ -297,6 +298,7 @@ Updated list packages of base system installation
 Добавлена обработка события отключения питания устройства
 Добавлена поддержка Ubuntu 15.10 (Wily Werewolf)
 Добавлена поддержка Fedora 22 (только armhfp)
+Добавлена поддержка Ubuntu amd64
 Добавлено больше локализаций
 Переведено на немецкий, итальянский, испанский и китайский языки
 

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -308,6 +308,7 @@
         <item>armhf</item>
         <item>arm64</item> <!-- saucy and later -->
         <item>i386</item>
+        <item>amd64</item>
     </string-array>
     <string-array name="ubuntu_components_values" translatable="false">
         <item>desktop</item>


### PR DESCRIPTION
This is a first attempt to support the amd64 architecture on Ubuntu for issue #254.  I don't have the android build environment functioning yet to test this.  If anyone is able to build the .apk I will gladly test it on my amd64 android device.  Linuxdeploy's code appears to be very generic regarding the deployment architecture, and this is a straightforward change so I think there's a good chance it will "just work".  Any comments are welcome.