### PR TITLE
Gradle build process

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry exported="true" kind="con" path="org.springsource.ide.eclipse.gradle.classpathcontainer"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
-	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry excluding="com/actionbarsherlock/actionbarsherlock/|com.actionbarsherlock/actionbarsherlock/|com/h6ah4i/android/compat/|com.h6ah4i.android.compat/" kind="src" path="build/intermediates/exploded-aar"/>
 	<classpathentry kind="src" path="gen"/>
-	<classpathentry kind="src" path="/actionbarsherlock"/>
+	<classpathentry kind="src" path="build/intermediates/exploded-aar/com.actionbarsherlock/actionbarsherlock"/>
+	<classpathentry kind="src" path="build/intermediates/exploded-aar/com.h6ah4i.android.compat"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,16 @@ local.properties
 # Generic save file patterns
 *~
 .*.swp
+
+# Gradle
+/build/
+/.gradle/
+/gradle/
+gradlew
+gradlew.bat
+
+# IDEA (Android Studio) metadata
+/.idea/
+*.iml
+
+

--- a/.project
+++ b/.project
@@ -1,68 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-
-    <name>
-LinuxDeploy
-    </name>
-
-    <comment>
+	<name>LinuxDeploy</name>
+	<comment>
     </comment>
-
-    <projects>
-    </projects>
-
-    <buildSpec>
-
-        <buildCommand>
-
-            <name>
-com.android.ide.eclipse.adt.ResourceManagerBuilder
-            </name>
-
-            <arguments>
-            </arguments>
-        </buildCommand>
-
-        <buildCommand>
-
-            <name>
-com.android.ide.eclipse.adt.PreCompilerBuilder
-            </name>
-
-            <arguments>
-            </arguments>
-        </buildCommand>
-
-        <buildCommand>
-
-            <name>
-org.eclipse.jdt.core.javabuilder
-            </name>
-
-            <arguments>
-            </arguments>
-        </buildCommand>
-
-        <buildCommand>
-
-            <name>
-com.android.ide.eclipse.adt.ApkBuilder
-            </name>
-
-            <arguments>
-            </arguments>
-        </buildCommand>
-    </buildSpec>
-
-    <natures>
-
-        <nature>
-com.android.ide.eclipse.adt.AndroidNature
-        </nature>
-
-        <nature>
-org.eclipse.jdt.core.javanature
-        </nature>
-    </natures>
-
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>com.android.ide.eclipse.adt.ResourceManagerBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>com.android.ide.eclipse.adt.PreCompilerBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>com.android.ide.eclipse.adt.ApkBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>com.android.ide.eclipse.adt.AndroidNature</nature>
+	</natures>
 </projectDescription>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:versionName="1.5.3" >
 
     <uses-sdk
-        android:minSdkVersion="7"
+        android:minSdkVersion="10"
         android:targetSdkVersion="19" />
 
     <uses-permission android:name="android.permission.INTERNET" />

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ repositories {
 dependencies {
     compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
     compile 'com.h6ah4i.android.compat:mulsellistprefcompat:1.0.0'
-    compile 'com.android.support:support-v4:23.0.0'
     compile fileTree(dir: 'libs', include: '*.jar')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,47 @@
+
+buildscript {
+    repositories {
+        jcenter()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.3.+'
+    }
+}
+apply plugin: 'com.android.application'
+
+repositories {
+    jcenter()
+    mavenCentral()
+}
+
+dependencies {
+    compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
+    compile 'com.h6ah4i.android.compat:mulsellistprefcompat:1.0.0'
+    compile 'com.android.support:support-v4:23.0.0'
+    compile fileTree(dir: 'libs', include: '*.jar')
+}
+
+android {
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            resources.srcDirs = []
+            aidl.srcDirs = []
+            renderscript.srcDirs = []
+            res.srcDirs = ['res']
+            assets.srcDirs = ['assets']
+        }
+
+        // Move the tests to tests/java, tests/res, etc...
+        instrumentTest.setRoot('tests')
+    }
+    
+      lintOptions {
+        disable 'MissingRegistered'
+  }
+}

--- a/project.properties
+++ b/project.properties
@@ -11,6 +11,6 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-19
-android.library.reference.1=../actionbarsherlock
-android.library.reference.2=../MultiSelectListPreferenceCompat
+target=android-22
+android.library.reference.1=../linuxdeploy/build/intermediates/exploded-aar/com.actionbarsherlock/actionbarsherlock/
+android.library.reference.2=../linuxdeploy/build/intermediates/exploded-aar/com.h6ah4i.android.compat/mulsellistprefcompat/


### PR DESCRIPTION
Please, review and merge my changes.
Created the gradle build for your project making much easier to build it from console or Android Studio (wrote to you on 4PDA).
Take a note:
- had to change minSdkVersion to 10 (as in available repository dependency for "mulsellistprefcompat");
- theoretically you even may remove "compile fileTree(dir: 'libs', include: '*.jar')" from "dependencies" node and libs/android-support-*, and change it to "compile 'com.android.support:support-v4:22.0.0' " to get if from repositories but I had problems building from console this way (while it was steel OK from Android Studio).