### PR TITLE
Force using busybox mount

### DIFF
--- a/assets/all/share/cli.sh
+++ b/assets/all/share/cli.sh
@@ -5,6 +5,9 @@
 #
 ################################################################################
 
+# force using busybox mount
+alias mount="busybox mount"
+
 msg()
 {
 if [ $# -gt 0 ]; then


### PR DESCRIPTION
On devices that use toolbox mount (or any incompatible mount symlink in /system/bin), we should force using our busybox mount that accepts the mount flags. We may replace each 'mount' with 'busybox mount' or just make this alias at the beginning of the main.sh script (currently, cli.sh).

This fixes: https://github.com/meefik/linuxdeploy/issues/358