### PR TITLE
fix missing liblz4 library in Arch Linux installation (issue #529)

### DIFF
--- a/assets/all/share/cli.sh
+++ b/assets/all/share/cli.sh
@@ -1502,7 +1502,7 @@ container_install()
     archlinux)
         msg "Installing Arch Linux distribution: "
 
-        local basic_packages="filesystem acl archlinux-keyring attr bash bzip2 ca-certificates coreutils cracklib curl db e2fsprogs expat findutils gawk gcc-libs gdbm glibc gmp gnupg gpgme grep keyutils krb5 libarchive libassuan libcap libgcrypt libgpg-error libgssglue libidn libksba libldap libsasl libssh2 libtirpc linux-api-headers lzo ncurses nettle openssl pacman pacman-mirrorlist pam pambase perl pinentry pth readline run-parts sed shadow sudo tzdata util-linux xz which zlib"
+        local basic_packages="filesystem acl archlinux-keyring attr bash bzip2 ca-certificates coreutils cracklib curl db e2fsprogs expat findutils gawk gcc-libs gdbm glibc gmp gnupg gpgme grep keyutils krb5 libarchive libassuan libcap libgcrypt libgpg-error libgssglue libidn libksba libldap libsasl libssh2 libtirpc linux-api-headers lz4 lzo ncurses nettle openssl pacman pacman-mirrorlist pam pambase perl pinentry pth readline run-parts sed shadow sudo tzdata util-linux xz which zlib"
 
         local platform=$(get_platform ${ARCH})
         if [ "${platform}" = "intel" ]


### PR DESCRIPTION
Hi,
   trying to install an Arch Linux based container, I found the liblz4 library problem described in issue 529 (https://github.com/meefik/linuxdeploy/issues/529).
After some attempts, I've fixed cli.sh to install liblz4 library during Arch Linux installation process and now it works properly.

Best regards.
--Domenico