### PR TITLE
If we're on the dark theme, set the mountpoint text to white

### DIFF
--- a/app/src/main/java/ru/meefik/linuxdeploy/MountsActivity.java
+++ b/app/src/main/java/ru/meefik/linuxdeploy/MountsActivity.java
@@ -2,6 +2,7 @@ package ru.meefik.linuxdeploy;
 
 import android.content.Context;
 import android.content.DialogInterface;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
@@ -128,6 +129,9 @@ public class MountsActivity extends AppCompatActivity {
                 String item = getItem(position);
 
                 ((TextView) view.findViewById(R.id.mount_point)).setText(item);
+                if (PrefStore.getTheme(this.getContext()) == R.style.DarkTheme) {
+                    ((TextView) view.findViewById(R.id.mount_point)).setTextColor(Color.WHITE);
+                }
 
                 view.findViewById(R.id.mount_point).setOnClickListener(new View.OnClickListener() {
                     @Override


### PR DESCRIPTION
For some reason this is black otherwise and basically unreadable

![photo_2018-11-09_12-08-15](https://user-images.githubusercontent.com/3220224/48261857-55861a00-e418-11e8-832a-8ec19fcd1f6c.jpg)
