### PR TITLE
Fix start on boot on android 8.1

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,6 +108,7 @@
 
         <service
             android:name=".ExecService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
             android:enabled="true"
             android:exported="false" />
     </application>

--- a/app/src/main/java/ru/meefik/linuxdeploy/EnvUtils.java
+++ b/app/src/main/java/ru/meefik/linuxdeploy/EnvUtils.java
@@ -494,7 +494,7 @@ class EnvUtils {
         Intent service = new Intent(c, ExecService.class);
         service.putExtra("cmd", cmd);
         service.putExtra("args", args);
-        c.startService(service);
+        ExecService.enqueueWork(c, service);
     }
 
     /**

--- a/app/src/main/java/ru/meefik/linuxdeploy/ExecService.java
+++ b/app/src/main/java/ru/meefik/linuxdeploy/ExecService.java
@@ -4,24 +4,19 @@ import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
+import android.support.annotation.NonNull;
+import android.support.v4.app.JobIntentService;
 
-public class ExecService extends Service {
+public class ExecService extends JobIntentService {
 
-    Context mContext;
+    public static final int JOB_ID = 1;
 
-    @Override
-    public void onCreate() {
-        super.onCreate();
-        mContext = getBaseContext();
+    public static void enqueueWork(Context context, Intent work) {
+        enqueueWork(context, ExecService.class, JOB_ID, work);
     }
 
     @Override
-    public IBinder onBind(Intent arg0) {
-        return null;
-    }
-
-    @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
+    protected void onHandleWork(@NonNull Intent intent) {
         if (intent != null) {
             final String cmd = intent.getStringExtra("cmd");
             final String args = intent.getStringExtra("args");
@@ -30,20 +25,19 @@ public class ExecService extends Service {
                 public void run() {
                     switch (cmd) {
                         case "telnetd":
-                            EnvUtils.telnetd(mContext, args);
+                            EnvUtils.telnetd(getBaseContext(), args);
                             break;
                         case "httpd":
-                            EnvUtils.httpd(mContext, args);
+                            EnvUtils.httpd(getBaseContext(), args);
                             break;
                         default:
-                            PrefStore.showNotification(mContext, null);
-                            EnvUtils.cli(mContext, cmd, args);
+                            PrefStore.showNotification(getBaseContext(), null);
+                            EnvUtils.cli(getBaseContext(), cmd, args);
                     }
                 }
             });
             thread.start();
         }
-        return super.onStartCommand(intent, flags, startId);
     }
 
 }


### PR DESCRIPTION
The container is not starting on boot on android 8.1 with these messages in logs:
Background start not allowed: service Intent { cmp=ru.meefik.linuxdeploy/.ExecService (has extras) } to ru.meefik.linuxdeploy/.ExecService from pid=4648 uid=10057 pkg=ru.meefik.linuxdeploy

and also:
ava.lang.RuntimeException: Unable to start receiver ru.meefik.linuxdeploy.BootReceiver: java.lang.IllegalStateException: Not allowed to start service Intent { cmp=ru.meefik.linuxdeploy/.ExecService (has extras) }: app is in background uid UidRecord{2d9564b u0a57 RCVR idle change:uncached procs:1 seq(0,0,0)}
