### PR TITLE
app preference for custom power trigger

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -93,6 +93,15 @@
             </intent-filter>
         </receiver>
         <receiver
+            android:name="PowerReceiver"
+            android:enabled="false"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.SCREEN_ON" />
+                <action android:name="android.intent.action.SCREEN_OFF" />
+            </intent-filter>
+        </receiver>
+        <receiver
             android:name=".ActionReceiver"
             android:enabled="true"
             android:exported="false">

--- a/app/src/main/java/ru/meefik/linuxdeploy/PowerReceiver.java
+++ b/app/src/main/java/ru/meefik/linuxdeploy/PowerReceiver.java
@@ -1,0 +1,13 @@
+package ru.meefik.linuxdeploy;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class PowerReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(final Context context, Intent intent) {
+        EnvUtils.execService(context, "start", "core/power");
+    }
+}

--- a/app/src/main/java/ru/meefik/linuxdeploy/PropertiesStore.java
+++ b/app/src/main/java/ru/meefik/linuxdeploy/PropertiesStore.java
@@ -13,7 +13,7 @@ class PropertiesStore extends ParamUtils {
     public static final String name = "properties_conf";
     private static final String[] params = {"method", "distrib", "arch", "suite", "source_path",
             "target_type", "target_path", "disk_size", "fs_type", "user_name", "user_password",
-            "privileged_users", "locale", "dns", "net_trigger", "init", "init_path", "init_level",
+            "privileged_users", "locale", "dns", "net_trigger", "power_trigger", "init", "init_path", "init_level",
             "init_user", "init_async", "ssh_port", "ssh_args", "pulse_host", "pulse_port", "graphics",
             "vnc_display", "vnc_depth", "vnc_dpi", "vnc_width", "vnc_height", "vnc_args",
             "x11_display", "x11_host", "x11_sdl", "x11_sdl_delay", "fb_display", "fb_dev",

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -51,6 +51,7 @@
     <string name="locale" translatable="false">C</string>
     <string name="dns" translatable="false"></string>
     <string name="net_trigger" translatable="false"></string>
+    <string name="power_trigger" translatable="false"></string>
     <string name="is_init" translatable="false">false</string>
     <string name="init" translatable="false">run-parts</string>
     <string name="init_path" translatable="false">/etc/rc.local</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -212,6 +212,9 @@
     <!-- NET_TRIGGER -->
     <string name="title_net_trigger_preference">Network trigger</string>
     <string name="dialog_title_net_trigger_preference">Path to trigger script</string>
+    <!-- POWER_TRIGGER -->
+    <string name="title_power_trigger_preference">Power trigger</string>
+    <string name="dialog_title_power_trigger_preference">Path to trigger script</string>
 
     <!-- INIT -->
     <string name="init_preferences">INIT</string>

--- a/app/src/main/res/xml/properties.xml
+++ b/app/src/main/res/xml/properties.xml
@@ -123,6 +123,13 @@
             android:summary="@string/net_trigger"
             android:title="@string/title_net_trigger_preference" />
 
+        <EditTextPreference
+            android:defaultValue="@string/power_trigger"
+            android:dialogTitle="@string/dialog_title_power_trigger_preference"
+            android:key="power_trigger"
+            android:summary="@string/power_trigger"
+            android:title="@string/title_power_trigger_preference" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/init_preferences">


### PR DESCRIPTION
This paves the way for a custom script to be run on power change events. The other half of this is https://github.com/meefik/linuxdeploy-cli/pull/15 which exposes a component in linuxdeploy-cli.

This can be used, for example, to re-disable power_save settings on the wlan0 interface when power state changes. See meefik/linuxdeploy#1092 for background.